### PR TITLE
move homepage to adcumn.com to prevent white screen on redirect

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adc-website",
   "version": "0.1.0",
-  "homepage": "https://vichofs.github.io/adc-website",
+  "homepage": "http://adcumn.com",
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^6.4.2",


### PR DESCRIPTION
This updates the package.json file to reflect the CNAME that was added, to allow http://adcumn.com to show the website instead of what is currently a white screen :)

This also pairs with #2 , which updates the gh-pages branch with the newly built artifacts :D 